### PR TITLE
Local corr check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,20 @@ dependencies = [
     "wandb",
 ]
 
+core_algo = [
+    "einops",
+    "h5py",
+    "kornia",
+    "loguru",
+    "opencv-contrib-python-headless",
+    "matplotlib",
+    "poselib>=2.0.4",
+    "timm",
+    "torch>=2.5.1",
+    "torchvision",
+    "tqdm"
+]
+
 [project.optional-dependencies]
 fused-local-corr = [
     "fused-local-corr>=0.2.2 ; sys_platform == 'linux'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ dependencies = [
     "wandb",
 ]
 
+
+[project.optional-dependencies]
+fused-local-corr = [
+    "fused-local-corr>=0.2.2 ; sys_platform == 'linux'",
+]
+
 core_algo = [
     "einops",
     "h5py",
@@ -35,11 +41,6 @@ core_algo = [
     "torch>=2.5.1",
     "torchvision",
     "tqdm"
-]
-
-[project.optional-dependencies]
-fused-local-corr = [
-    "fused-local-corr>=0.2.2 ; sys_platform == 'linux'",
 ]
 
 [build-system]

--- a/romatch/models/matcher.py
+++ b/romatch/models/matcher.py
@@ -50,6 +50,13 @@ class ConvRefiner(nn.Module):
         if sys.platform != "linux":
             warn("Local correlation is not supported on non-Linux platforms, setting use_custom_corr to False")
             use_custom_corr = False
+        if use_custom_corr:
+            try:
+                import local_corr  # noqa: F401
+            except ImportError:
+                warn("local_corr extension not installed; "
+                     "setting use_custom_corr to False")
+                use_custom_corr = False
         self.bn_momentum = bn_momentum
         self.block1 = self.create_block(
             in_dim,


### PR DESCRIPTION
This PR does a few things aimed at making the romatch-roicat code easier to use as a dependency: 
1. It makes a [core_algo] optional dependency that contains the minimum set of requirements needed to support tracking in roicat
2. It fixes a bug in roma/models/matching.py. In that module, there is some logic that checks whether the os is/isn't linux, and accordingly does a lazy install of some linux-specific libs (fused-local-corr). Code is here. https://github.com/apasarkar/RoMa/blob/4d5967525763b301888d344b79e24df60ec33726/romatch/models/matcher.py#L52. This code does not account for the case that the linux user installed RoMa but opted out of installing the extra [fused-local-corr] dep. 